### PR TITLE
Add support for ZAR and fix supported currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ DumbBudget supports the following currencies:
 - INR (Indian Rupee) 🇮🇳
 - BRL (Brazilian Real) 🇧🇷
 - ZAR (South African Rand) 🇿🇦
+- TRY (Turkish Lira) 🇹🇷  
+- PLN (Polish Złoty) 🇵🇱  
+- SEK (Swedish Krona) 🇸🇪  
+- NOK (Norwegian Krone) 🇳🇴  
+- DKK (Danish Krone) 🇩🇰  
 
 Set your preferred currency using the `CURRENCY` environment variable (defaults to USD if not set).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ DumbBudget supports the following currencies:
 - KRW (South Korean Won) 🇰🇷
 - INR (Indian Rupee) 🇮🇳
 - BRL (Brazilian Real) 🇧🇷
+- ZAR (South African Rand) 🇿🇦
 
 Set your preferred currency using the `CURRENCY` environment variable (defaults to USD if not set).
 

--- a/public/script.js
+++ b/public/script.js
@@ -182,8 +182,7 @@ const SUPPORTED_CURRENCIES = {
     PLN: { locale: 'pl-PL', symbol: 'zł' },
     SEK: { locale: 'sv-SE', symbol: 'kr' },
     NOK: { locale: 'nb-NO', symbol: 'kr' },
-    DKK: { locale: 'da-DK', symbol: 'kr' },
-    ZAR: { locale: 'en-ZA', symbol: 'R' }
+    DKK: { locale: 'da-DK', symbol: 'kr' }
 };
 
 let currentCurrency = 'USD'; // Default currency

--- a/public/script.js
+++ b/public/script.js
@@ -182,7 +182,8 @@ const SUPPORTED_CURRENCIES = {
     PLN: { locale: 'pl-PL', symbol: 'zł' },
     SEK: { locale: 'sv-SE', symbol: 'kr' },
     NOK: { locale: 'nb-NO', symbol: 'kr' },
-    DKK: { locale: 'da-DK', symbol: 'kr' }
+    DKK: { locale: 'da-DK', symbol: 'kr' },
+    ZAR: { locale: 'en-ZA', symbol: 'R' }
 };
 
 let currentCurrency = 'USD'; // Default currency

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+const dotenv = require('dotenv').config();
 const express = require('express');
 const session = require('express-session');
 const helmet = require('helmet');
@@ -622,7 +622,10 @@ app.delete('/api/transactions/:id', authMiddleware, async (req, res) => {
 // Supported currencies list - must match client-side list
 const SUPPORTED_CURRENCIES = [
     'USD', 'EUR', 'GBP', 'JPY', 'AUD', 
-    'CAD', 'CHF', 'CNY', 'HKD', 'NZD'
+    'CAD', 'CHF', 'CNY', 'HKD', 'NZD',
+    'MXN', 'RUB', 'SGD', 'KRW', 'INR',
+    'BRL', 'ZAR', 'TRY', 'PLN', 'SEK',
+    'NOK', 'DKK'
 ];
 
 // Get current currency setting


### PR DESCRIPTION
I initially added a line in for ZAR and updated the README but in testing I was still only seeing USD as the currency. After looking a bit deeper I see that you have an array of supported currencies in server.js as well which hadn't been updated to match the supported currencies in script.js. Basically, even adding in new currencies in script.js would always cause the app to fall back to USD. 

I have updated the supported currencies between script.js, server.js and the README and after testing, it works. I think it would be simpler to maintain the supported currencies in a separate JSON file which you can then parse from both the server and client side.