### PR TITLE
Allow User to control the name of their instance (updated in the UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ docker run -d \
   -e DUMBBUDGET_PIN=12345 \
   -e CURRENCY=USD \
   -e BASE_URL=http://localhost:3000 \
+  -e INSTANCE_NAME='My Account' \
   dumbwareio/dumbbudget:latest
 ```
 
@@ -69,6 +70,7 @@ docker run -d \
 | `PORT` | Port number for the server | No | `3000` | `8080` |
 | `CURRENCY` | Currency code for transactions | No | `USD` | `EUR` |
 | `BASE_URL` | Base URL for the application | No | `http://localhost:PORT` | `https://budget.example.com` |
+| `INSTANCE_NAME` | Allows you to name each instance should you have multiple. | No | - | `My Account` |
 
 ## Development Setup
 
@@ -90,6 +92,7 @@ PORT=3000
 NODE_ENV=development
 BASE_URL=http://localhost:3000
 CURRENCY=USD
+INSTANCE_NAME='My Account'
 ```
 
 4. Start the development server:
@@ -114,6 +117,7 @@ docker run -d \
   -v ~/dumbbudget-data:/app/data \
   -e DUMBBUDGET_PIN=12345 \
   -e BASE_URL=http://localhost:3000 \
+  -e INSTANCE_NAME='My Account' \
   dumbwareio/dumbbudget:latest
 ```
 

--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
             </button>
 
             <header>
-                <h1>DumbBudget</h1>
+                <h1><span id="instance-name">DumbBudget</span></h1>
             </header>
 
             <section class="overview">

--- a/public/login.html
+++ b/public/login.html
@@ -26,7 +26,7 @@
                     <line x1="18.36" y1="5.64" x2="19.78" y1="4.22"></line>
                 </svg>
             </button>
-            <h1>DumbBudget</h1>
+            <h1><span id="instance-name">DumbBudget</span></h1>
             <h2>Enter PIN</h2>
             <div class="pin-input-container"></div>
             <div class="pin-error" role="alert" aria-hidden="true">Incorrect PIN. Please try again.</div>

--- a/public/script.js
+++ b/public/script.js
@@ -58,6 +58,20 @@ function joinPath(path) {
     return result;
 }
 
+// Fetch config with instance name
+async function updateInstanceName() {
+    try {
+        const res = await fetch(joinPath('api/config'), fetchConfig);
+        const data = await res.json();
+        document.title = data.instanceName;
+        document.getElementById('instance-name').textContent = data.instanceName;
+    } catch (error) {
+        console.error('Error fetching instance name, falling back to default. Error: ', error);
+        document.title = 'DumbBudget';
+        document.getElementById('instance-name').textContent = 'DumbBudget';
+    }
+}
+
 // PIN input functionality
 function setupPinInputs() {
     const form = document.getElementById('pinForm');
@@ -691,4 +705,5 @@ document.addEventListener('DOMContentLoaded', () => {
     setupPinInputs();
     initModalHandling();
     initMainPage();
+    updateInstanceName();
 }); 

--- a/server.js
+++ b/server.js
@@ -199,6 +199,16 @@ app.get(BASE_PATH + '/login', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'login.html'));
 });
 
+app.get(BASE_PATH + '/api/config', (req, res) => {
+    let instanceName = process.env.INSTANCE_NAME;
+    if (instanceName == undefined) {
+        instanceName = 'DumbBudget';
+    } else {
+        instanceName = `DumbBudget - ${process.env.INSTANCE_NAME}`
+    }
+    res.json({ instanceName: instanceName });
+});
+
 app.get(BASE_PATH + '/pin-length', (req, res) => {
     // If no PIN is set, return 0 length
     if (!PIN || PIN.trim() === '') {


### PR DESCRIPTION
In the case of a user hosting multiple instances of DumbBudget (for multiple bank accounts, or multiple budgets within a single bank account), allow them to control the name displayed in the Applications title and header. It makes it easier to see which "account" you're working in.

If env var INSTANCE_NAME is set, the UI will display "DumbBudget - {INSTANCE_NAME}", else, it will fall back to only "DumbBudget".

Minimal code to keep everything simple.