### PR TITLE
Added Philippine Peso

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -237,7 +237,8 @@ const SUPPORTED_CURRENCIES = {
     SEK: { locale: 'sv-SE', symbol: 'kr' },
     NOK: { locale: 'nb-NO', symbol: 'kr' },
     DKK: { locale: 'da-DK', symbol: 'kr' },
-    IDR: { locale: 'id-ID', symbol: 'Rp' }
+    IDR: { locale: 'id-ID', symbol: 'Rp' },
+    PHP: { locale: 'fil-PH', symbol: '₱' }
 };
 
 let currentCurrency = 'USD'; // Default currency


### PR DESCRIPTION
Ensures that PHP (Philippine Peso) is recognized with the correct locale (fil-PH) and symbol (₱).







