### PR TITLE
Fix handling of text/csv contenttype from handleFetchResponse on export

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -305,8 +305,8 @@ async function handleFetchResponse(response) {
 
     // Check content type
     const contentType = response.headers.get('content-type');
-    if (!contentType || !contentType.includes('application/json')) {
-        debugLog('Response is not JSON, session likely expired');
+    if (!contentType || (!contentType.includes('application/json') && !contentType.includes('text/csv'))) {
+        debugLog('Response is not JSON or CSV, session likely expired');
         window.location.href = joinPath('login');
         return null;
     }


### PR DESCRIPTION
@abiteman 
Issue: https://github.com/DumbWareio/DumbBudget/issues/29

i believe the export functionality used to be working and seems like the regression was introduced in commit: 8919fd5

<details>
<summary>Previews:</summary>

![export-preview](https://github.com/user-attachments/assets/380b1f75-7e2d-4430-9705-39e0e4ce7b16)
</details>

Change:
- Updated `handleFetchReponse` function to include`text/csv` in final `if` block to allow csv content types from api responses