### PR TITLE
Update Github CD workflow for arm64 image docker

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -31,16 +34,18 @@ jobs:
       - name: Set Docker tags
         id: docker_meta
         run: |
+          TAGS="${{ env.DOCKER_IMAGE }}:${{ github.sha }}"
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "DOCKER_TAGS=${DOCKER_IMAGE}:latest" >> $GITHUB_ENV
+            TAGS+=" ${{ env.DOCKER_IMAGE }}:latest"
           elif [ "${{ github.ref }}" = "refs/heads/testing" ]; then
-            echo "DOCKER_TAGS=${DOCKER_IMAGE}:testing" >> $GITHUB_ENV
+            TAGS+=" ${{ env.DOCKER_IMAGE }}:testing"
           fi
+          echo "DOCKER_TAGS=$TAGS" >> $GITHUB_ENV
 
-      - name: Build Docker Image
+      - name: Build and Push Multi-Platform Image
         run: |
-          docker build -t ${{ env.DOCKER_TAGS }} .
-
-      - name: Push Docker Image
-        run: |
-          docker push ${{ env.DOCKER_TAGS }} 
+          docker buildx create --use
+          docker buildx build --platform ${{ env.PLATFORMS }} \
+            --tag ${{ env.DOCKER_IMAGE }}:${{ github.sha }} \
+            --tag ${{ env.DOCKER_IMAGE }}:latest \
+            --push .


### PR DESCRIPTION
@abiteman saw that arm64 was added here but it wasn't getting pushed? just updating DumbBudget to include the same as DumbDo to include images for latest / sha for both architectures
- looks like rest already include arm64 on dockerhub!
- https://hub.docker.com/r/dumbwareio/dumbbudget/tags (missing arm64)

issue: https://github.com/DumbWareio/DumbDo/issues/23