### PR TITLE
# Fix: Transaction Type Reference Error in Edit Mode

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -470,6 +470,9 @@ function editTransaction(id, transaction, isRecurringInstance) {
     document.getElementById('description').value = transaction.description;
     document.getElementById('transactionDate').value = transaction.date;
     
+    // Update the currentTransactionType to match the transaction being edited
+    currentTransactionType = transaction.type;
+    
     // Set transaction type
     toggleBtns.forEach(btn => {
         btn.classList.toggle('active', btn.dataset.type === transaction.type);

--- a/public/script.js
+++ b/public/script.js
@@ -324,6 +324,9 @@ let editingTransactionId = null;
 let currentSortField = 'date';
 let currentSortDirection = 'desc';
 
+// Add currentTransactionType as a global variable
+let currentTransactionType = 'income'; // Default transaction type
+
 // Update loadTransactions function
 async function loadTransactions() {
     try {
@@ -653,8 +656,6 @@ function initModalHandling() {
     const categoryField = document.getElementById('categoryField');
     const toggleBtns = document.querySelectorAll('.toggle-btn');
     const amountInput = document.getElementById('amount');
-
-    let currentTransactionType = 'income';
 
     // Initialize category handling
     initCategoryHandling();

--- a/public/script.js
+++ b/public/script.js
@@ -1,6 +1,13 @@
 import { ToastManager } from "./managers/toast";
 const toastManager = new ToastManager(document.getElementById('toast-container'));
 
+// Global variables
+let currentTransactionType = 'income'; // Default transaction type
+let currentFilter = null; // null = show all, 'income' = only income, 'expense' = only expenses
+let editingTransactionId = null;
+let currentSortField = 'date';
+let currentSortDirection = 'desc';
+
 // Theme toggle functionality
 function getBaseUrl() {
     // First try to get it from the server-provided meta tag
@@ -313,19 +320,6 @@ async function handleFetchResponse(response) {
 
     return response;
 }
-
-// Add currentFilter variable at the top with other shared variables
-let currentFilter = null; // null = show all, 'income' = only income, 'expense' = only expenses
-
-// Add at the top with other variables
-let editingTransactionId = null;
-
-// Add at the top with other shared variables
-let currentSortField = 'date';
-let currentSortDirection = 'desc';
-
-// Add currentTransactionType as a global variable
-let currentTransactionType = 'income'; // Default transaction type
 
 // Update loadTransactions function
 async function loadTransactions() {


### PR DESCRIPTION
Fixes #32 

## Issue
Fixed issue #32 where editing a transaction would throw a `ReferenceError: currentTransactionType is not defined` error. This occurred when trying to edit a transaction after previously editing another transaction.

## Changes Made
- Moved all global variable declarations to the top of the file for better organization and initialization
- Consolidated scattered variable declarations into a single global variables section
- Ensured `currentTransactionType` is properly initialized before any function usage
- Removed duplicate declarations that were scattered throughout the file

## Technical Details
The issue was caused by the `currentTransactionType` variable being declared in the middle of the file, which could lead to reference errors if the code execution path didn't reach that declaration before using the variable. By moving it to the top of the file with other global variables, we ensure it's always properly initialized before use.

## Testing
The fix has been tested by:
1. Editing an expense transaction
2. Editing an income transaction
3. Verifying that the transaction type remains correct during edits
4. Confirming no more reference errors occur

## Impact
This change improves the reliability of the transaction editing functionality and prevents potential type switching issues when editing different types of transactions in sequence.